### PR TITLE
feat: estimated reading time

### DIFF
--- a/src/app/(frontend)/articles/page.tsx
+++ b/src/app/(frontend)/articles/page.tsx
@@ -23,6 +23,7 @@ export default async function Page() {
       title: true,
       slug: true,
       categories: true,
+      content: true,
       meta: true,
       publishedAt: true,
       authors: true,

--- a/src/app/(frontend)/search/page.tsx
+++ b/src/app/(frontend)/search/page.tsx
@@ -6,7 +6,7 @@ import { getPayload } from 'payload'
 import React from 'react'
 import { Search } from '@/search/Component'
 import PageClient from './page.client'
-import { CardArticleData } from '@/components/Card'
+import { CardSearchSource } from '@/utilities/articleCardData'
 
 type Args = {
   searchParams: Promise<{
@@ -27,8 +27,8 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       categories: true,
       meta: true,
       publishedAt: true,
-      authors: true,
       populatedAuthors: true,
+      readingTimeMinutes: true,
     },
     // pagination: false reduces overhead if you don't need totalDocs
     pagination: false,
@@ -76,7 +76,7 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
       </div>
 
       {articles.totalDocs > 0 ? (
-        <CollectionArchive articles={articles.docs as CardArticleData[]} />
+        <CollectionArchive articles={articles.docs as CardSearchSource[]} />
       ) : (
         <div className="container">No results found.</div>
       )}

--- a/src/blocks/RelatedArticles/Component.tsx
+++ b/src/blocks/RelatedArticles/Component.tsx
@@ -6,6 +6,7 @@ import type { Article } from '@/payload-types'
 
 import { Card } from '../../components/Card'
 import { DefaultTypedEditorState } from '@payloadcms/richtext-lexical'
+import { toCardArticleData } from '@/utilities/articleCardData'
 
 export type RelatedArticlesProps = {
   className?: string
@@ -24,7 +25,7 @@ export const RelatedArticles: React.FC<RelatedArticlesProps> = (props) => {
         {docs?.map((doc, index) => {
           if (typeof doc === 'string') return null
 
-          return <Card key={index} doc={doc} relationTo="articles" />
+          return <Card key={index} doc={toCardArticleData(doc)} relationTo="articles" />
         })}
       </div>
     </div>

--- a/src/collections/Articles/index.ts
+++ b/src/collections/Articles/index.ts
@@ -44,6 +44,7 @@ export const Articles: CollectionConfig<'articles'> = {
     title: true,
     slug: true,
     categories: true,
+    content: true,
     meta: {
       image: true,
       description: true,

--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -4,17 +4,12 @@ import useClickableCard from '@/utilities/useClickableCard'
 import Link from 'next/link'
 import React from 'react'
 
-import type { Article, Category } from '@/payload-types'
-
 import { Media } from '@/components/Media'
 import { Badge } from '../ui/badge'
 import { formatAuthors } from '@/utilities/formatAuthors'
 import { formatReadableDate } from '@/utilities/formatReadableDate'
-
-export type CardArticleData = Pick<
-  Article,
-  'slug' | 'categories' | 'meta' | 'title' | 'populatedAuthors' | 'publishedAt'
->
+import { formatReadingTime } from '@/utilities/readingTime'
+import type { CardArticleData } from '@/utilities/articleCardData'
 
 export const Card: React.FC<{
   alignItems?: 'center'
@@ -27,17 +22,14 @@ export const Card: React.FC<{
   const { card, link } = useClickableCard({})
   const { className, doc, relationTo, showCategories, title: titleFromProps } = props
 
-  const { slug, categories, meta, title, populatedAuthors, publishedAt } = doc || {}
+  const { slug, categories, meta, title, populatedAuthors, publishedAt, readingTimeMinutes } =
+    doc || {}
   const { description, image: metaImage } = meta || {}
 
   const titleToUse = titleFromProps || title
-  const validCategories =
-    categories?.filter(
-      (category): category is Category =>
-        typeof category === 'object' && category !== null && !!category.title,
-    ) ?? []
   const sanitizedDescription = description?.replace(/\s/g, ' ') // replace non-breaking space with white space
-  const author = populatedAuthors?.[0]
+  const authorLabel = populatedAuthors ? formatAuthors(populatedAuthors) : ''
+  const readingTimeLabel = formatReadingTime(readingTimeMinutes)
   const href = `/${relationTo}/${slug}`
 
   return (
@@ -71,9 +63,9 @@ export const Card: React.FC<{
         )}
 
         {/* Categories */}
-        {showCategories && validCategories.length > 0 && (
+        {showCategories && categories && categories.length > 0 && (
           <div className="flex flex-wrap gap-1 text-sm my-2">
-            {validCategories.map((category) => (
+            {categories.map((category) => (
               <Badge key={category.id} variant="outline">
                 {category.title}
               </Badge>
@@ -83,9 +75,11 @@ export const Card: React.FC<{
 
         <div className="text-xs text-muted-foreground flex flex-wrap gap-3 my-2">
           {/* Author */}
-          {author && <div className="font-medium">{formatAuthors(populatedAuthors)}</div>}
+          {authorLabel && <div className="font-medium">{authorLabel}</div>}
           {/* Date */}
           {publishedAt && <div>{formatReadableDate(publishedAt)}</div>}
+          {/* Reading time */}
+          {readingTimeLabel && <div>{readingTimeLabel}</div>}
         </div>
 
         {/* Description */}

--- a/src/components/CollectionArchive/index.tsx
+++ b/src/components/CollectionArchive/index.tsx
@@ -1,10 +1,11 @@
 import { cn } from '@/utilities/ui'
 import React from 'react'
 
-import { Card, CardArticleData } from '@/components/Card'
+import { Card } from '@/components/Card'
+import { CardSourceData, toCardArticleData } from '@/utilities/articleCardData'
 
 export type Props = {
-  articles: CardArticleData[]
+  articles: CardSourceData[]
 }
 
 export const CollectionArchive: React.FC<Props> = (props) => {
@@ -18,7 +19,7 @@ export const CollectionArchive: React.FC<Props> = (props) => {
             if (typeof result === 'object' && result !== null) {
               return (
                 <div className="col-span-4" key={index}>
-                  <Card className="h-full" doc={result} relationTo="articles" />
+                  <Card className="h-full" doc={toCardArticleData(result)} relationTo="articles" />
                 </div>
               )
             }

--- a/src/components/SectionArchive/index.tsx
+++ b/src/components/SectionArchive/index.tsx
@@ -30,6 +30,7 @@ export async function SectionArchive({ section, sectionLabel, page = 1 }: Props)
       title: true,
       slug: true,
       categories: true,
+      content: true,
       meta: true,
       publishedAt: true,
       authors: true,

--- a/src/heros/ArticleHero/index.tsx
+++ b/src/heros/ArticleHero/index.tsx
@@ -4,6 +4,7 @@ import { Media } from '@/components/Media'
 import { formatAuthors } from '@/utilities/formatAuthors'
 import { formatReadableDate } from '@/utilities/formatReadableDate'
 import { Badge } from '@/components/ui/badge'
+import { formatReadingTime, getReadingTimeMinutes } from '@/utilities/readingTime'
 
 export const ArticleHero: React.FC<{
   article: Article
@@ -15,6 +16,7 @@ export const ArticleHero: React.FC<{
 
   const publishedDate = publishedAt ? formatReadableDate(publishedAt) : null
   const updatedDate = updatedAt ? formatReadableDate(updatedAt) : null
+  const readingTimeLabel = formatReadingTime(getReadingTimeMinutes(article.content))
   const showUpdated = updatedDate && updatedDate !== publishedDate
 
   return (
@@ -47,9 +49,10 @@ export const ArticleHero: React.FC<{
         )}
 
         {/* Dates */}
-        {(publishedDate || showUpdated) && (
+        {(publishedDate || readingTimeLabel || showUpdated) && (
           <div className="flex flex-wrap items-center gap-x-4 gap-y-0.5 text-sm text-muted-foreground">
             {publishedDate && <time dateTime={publishedAt!}>{publishedDate}</time>}
+            {readingTimeLabel && <div>{readingTimeLabel}</div>}
             {showUpdated && (
               <time dateTime={updatedAt} className="text-muted-foreground/70">
                 Updated {updatedDate}

--- a/src/migrations/20260318_120000_add_search_reading_time_fields.ts
+++ b/src/migrations/20260318_120000_add_search_reading_time_fields.ts
@@ -1,0 +1,27 @@
+import { MigrateDownArgs, MigrateUpArgs, sql } from '@payloadcms/db-postgres'
+
+export async function up({ db }: MigrateUpArgs): Promise<void> {
+  await db.execute(sql`
+   ALTER TABLE "search" ADD COLUMN "published_at" timestamp(3) with time zone;
+  ALTER TABLE "search" ADD COLUMN "reading_time_minutes" numeric;
+  CREATE TABLE "search_populated_authors" (
+  	"_order" integer NOT NULL,
+  	"_parent_id" integer NOT NULL,
+  	"id" varchar PRIMARY KEY NOT NULL,
+  	"name" varchar
+  );
+  ALTER TABLE "search_populated_authors" ADD CONSTRAINT "search_populated_authors_parent_id_fk" FOREIGN KEY ("_parent_id") REFERENCES "public"."search"("id") ON DELETE cascade ON UPDATE no action;
+  CREATE INDEX "search_published_at_idx" ON "search" USING btree ("published_at");
+  CREATE INDEX "search_reading_time_minutes_idx" ON "search" USING btree ("reading_time_minutes");
+  CREATE INDEX "search_populated_authors_order_idx" ON "search_populated_authors" USING btree ("_order");
+  CREATE INDEX "search_populated_authors_parent_id_idx" ON "search_populated_authors" USING btree ("_parent_id");`)
+}
+
+export async function down({ db }: MigrateDownArgs): Promise<void> {
+  await db.execute(sql`
+   DROP TABLE "search_populated_authors" CASCADE;
+  DROP INDEX "search_published_at_idx";
+  DROP INDEX "search_reading_time_minutes_idx";
+  ALTER TABLE "search" DROP COLUMN "published_at";
+  ALTER TABLE "search" DROP COLUMN "reading_time_minutes";`)
+}

--- a/src/migrations/index.ts
+++ b/src/migrations/index.ts
@@ -1,6 +1,7 @@
 import * as migration_20260316_141145_initial from './20260316_141145_initial'
 import * as migration_20260316_141257_rename_posts_to_articles from './20260316_141257_rename_posts_to_articles'
 import * as migration_20260317_131609_add_article_section_field from './20260317_131609_add_article_section_field'
+import * as migration_20260318_120000_add_search_reading_time_fields from './20260318_120000_add_search_reading_time_fields'
 
 export const migrations = [
   {
@@ -17,5 +18,10 @@ export const migrations = [
     up: migration_20260317_131609_add_article_section_field.up,
     down: migration_20260317_131609_add_article_section_field.down,
     name: '20260317_131609_add_article_section_field',
+  },
+  {
+    up: migration_20260318_120000_add_search_reading_time_fields.up,
+    down: migration_20260318_120000_add_search_reading_time_fields.down,
+    name: '20260318_120000_add_search_reading_time_fields',
   },
 ]

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -841,6 +841,14 @@ export interface Search {
     value: number | Article;
   };
   slug?: string | null;
+  publishedAt?: string | null;
+  populatedAuthors?:
+    | {
+        name?: string | null;
+        id?: string | null;
+      }[]
+    | null;
+  readingTimeMinutes?: number | null;
   meta?: {
     title?: string | null;
     description?: string | null;
@@ -1533,6 +1541,14 @@ export interface SearchSelect<T extends boolean = true> {
   priority?: T;
   doc?: T;
   slug?: T;
+  publishedAt?: T;
+  populatedAuthors?:
+    | T
+    | {
+        name?: T;
+        id?: T;
+      };
+  readingTimeMinutes?: T;
   meta?:
     | T
     | {

--- a/src/search/beforeSync.ts
+++ b/src/search/beforeSync.ts
@@ -1,15 +1,24 @@
 import { BeforeSync, DocToSync } from '@payloadcms/plugin-search/types'
+import { getReadingTimeMinutes } from '@/utilities/readingTime'
+import type { Article } from '@/payload-types'
 
 export const beforeSyncWithSearch: BeforeSync = async ({ req, originalDoc, searchDoc }) => {
   const {
     doc: { relationTo: collection },
   } = searchDoc
 
-  const { slug, id, categories, title, meta } = originalDoc
+  const { slug, id, categories, title, meta, publishedAt, populatedAuthors, content } = originalDoc
 
   const modifiedDoc: DocToSync = {
     ...searchDoc,
     slug,
+    publishedAt,
+    populatedAuthors: populatedAuthors?.map(
+      (author: NonNullable<NonNullable<Article['populatedAuthors']>[number]>) => ({
+        name: author?.name,
+      }),
+    ),
+    readingTimeMinutes: getReadingTimeMinutes(content),
     meta: {
       ...meta,
       title: meta?.title || title,

--- a/src/search/fieldOverrides.ts
+++ b/src/search/fieldOverrides.ts
@@ -10,6 +10,35 @@ export const searchFields: Field[] = [
     },
   },
   {
+    name: 'publishedAt',
+    type: 'date',
+    index: true,
+    admin: {
+      readOnly: true,
+    },
+  },
+  {
+    name: 'populatedAuthors',
+    type: 'array',
+    admin: {
+      readOnly: true,
+    },
+    fields: [
+      {
+        name: 'name',
+        type: 'text',
+      },
+    ],
+  },
+  {
+    name: 'readingTimeMinutes',
+    type: 'number',
+    index: true,
+    admin: {
+      readOnly: true,
+    },
+  },
+  {
     name: 'meta',
     label: 'Meta',
     type: 'group',

--- a/src/utilities/articleCardData.ts
+++ b/src/utilities/articleCardData.ts
@@ -1,0 +1,83 @@
+import type { Article, Search } from '@/payload-types'
+
+import { getReadingTimeMinutes } from '@/utilities/readingTime'
+
+type CardAuthorData = NonNullable<NonNullable<Article['populatedAuthors']>[number]>
+
+export type CardCategoryData = {
+  id: string | number
+  title: string
+}
+
+export type CardArticleData = {
+  slug?: string | null
+  categories?: CardCategoryData[] | null
+  meta?: Article['meta']
+  title?: string | null
+  populatedAuthors?: CardAuthorData[] | null
+  publishedAt?: string | null
+  readingTimeMinutes?: number | null
+}
+
+type ArticleCardSource = Pick<
+  Article,
+  'slug' | 'categories' | 'meta' | 'title' | 'populatedAuthors' | 'publishedAt' | 'content'
+>
+
+export type CardSearchSource = Pick<Search, 'slug' | 'categories' | 'meta' | 'title'> & {
+  publishedAt?: string | null
+  populatedAuthors?: CardAuthorData[] | null
+  readingTimeMinutes?: number | null
+}
+
+export type CardSourceData = ArticleCardSource | CardSearchSource
+
+const normalizeCategories = (
+  categories: ArticleCardSource['categories'] | CardSearchSource['categories'],
+): CardCategoryData[] => {
+  const normalizedCategories: CardCategoryData[] = []
+
+  categories?.forEach((category) => {
+    if (!category || typeof category !== 'object' || !category.title) {
+      return
+    }
+
+    if ('categoryID' in category) {
+      normalizedCategories.push({
+        id: category.categoryID || category.id || category.title,
+        title: category.title,
+      })
+      return
+    }
+
+    normalizedCategories.push({
+      id: category.id ?? category.title,
+      title: category.title,
+    })
+  })
+
+  return normalizedCategories
+}
+
+export const toCardArticleData = (doc: CardSourceData): CardArticleData => {
+  const baseCardData: CardArticleData = {
+    slug: doc.slug,
+    categories: normalizeCategories(doc.categories),
+    meta: doc.meta,
+    title: doc.title,
+    populatedAuthors: doc.populatedAuthors,
+    publishedAt: doc.publishedAt,
+  }
+
+  if ('content' in doc) {
+    return {
+      ...baseCardData,
+      readingTimeMinutes: getReadingTimeMinutes(doc.content),
+    }
+  }
+
+  return {
+    ...baseCardData,
+    readingTimeMinutes: doc.readingTimeMinutes ?? null,
+  }
+}

--- a/src/utilities/readingTime.spec.ts
+++ b/src/utilities/readingTime.spec.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  READING_TIME_WORDS_PER_MINUTE,
+  extractReadingTimeText,
+  formatReadingTime,
+  getReadingTimeMinutes,
+} from './readingTime'
+
+const createTextNode = (text: string) => ({
+  type: 'text',
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  text,
+  version: 1,
+})
+
+const createParagraph = (text: string) => ({
+  type: 'paragraph',
+  children: [createTextNode(text)],
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  textFormat: 0,
+  version: 1,
+})
+
+const createContent = (...children: unknown[]) => ({
+  root: {
+    type: 'root',
+    children,
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    version: 1,
+  },
+})
+
+describe('readingTime', () => {
+  it('extracts readable text and code from lexical content', () => {
+    const content = createContent(
+      createParagraph('Alpha beta gamma'),
+      {
+        type: 'block',
+        fields: {
+          blockType: 'code',
+          code: 'const answer = 42',
+        },
+        format: '',
+        version: 2,
+      },
+      {
+        type: 'block',
+        fields: {
+          blockType: 'banner',
+          content: createContent(createParagraph('Delta epsilon')),
+        },
+        format: '',
+        version: 2,
+      },
+    )
+
+    expect(extractReadingTimeText(content)).toBe('Alpha beta gamma const answer = 42 Delta epsilon')
+  })
+
+  it('rounds up using the 200 wpm baseline', () => {
+    const words = Array.from(
+      { length: READING_TIME_WORDS_PER_MINUTE + 1 },
+      (_, index) => `word-${index + 1}`,
+    ).join(' ')
+    const content = createContent(createParagraph(words))
+
+    expect(getReadingTimeMinutes(content)).toBe(2)
+  })
+
+  it('returns a minimum of one minute for non-empty content and null for empty formatting output', () => {
+    const content = createContent(createParagraph('Pagbutlak'))
+
+    expect(getReadingTimeMinutes(content)).toBe(1)
+    expect(formatReadingTime(1)).toBe('1 min read')
+    expect(formatReadingTime(0)).toBeNull()
+  })
+})

--- a/src/utilities/readingTime.ts
+++ b/src/utilities/readingTime.ts
@@ -1,0 +1,75 @@
+export const READING_TIME_WORDS_PER_MINUTE = 200
+
+const READING_TIME_CONTENT_KEYS = new Set(['text', 'code'])
+
+const collectReadingTimeText = (value: unknown, segments: string[]): void => {
+  if (!value) {
+    return
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item) => collectReadingTimeText(item, segments))
+    return
+  }
+
+  if (typeof value !== 'object') {
+    return
+  }
+
+  Object.entries(value).forEach(([key, nestedValue]) => {
+    if (typeof nestedValue === 'string') {
+      if (READING_TIME_CONTENT_KEYS.has(key) && nestedValue.trim()) {
+        segments.push(nestedValue.trim())
+      }
+      return
+    }
+
+    collectReadingTimeText(nestedValue, segments)
+  })
+}
+
+export const extractReadingTimeText = (content: unknown): string => {
+  if (!content) {
+    return ''
+  }
+
+  const segments: string[] = []
+  collectReadingTimeText(content, segments)
+
+  return segments.join(' ').trim()
+}
+
+export const getWordCount = (text: string): number => {
+  const normalizedText = text.replace(/\u00A0/g, ' ').trim()
+
+  if (!normalizedText) {
+    return 0
+  }
+
+  return normalizedText.split(/\s+/).length
+}
+
+export const getReadingTimeMinutes = (
+  content: unknown,
+  wordsPerMinute = READING_TIME_WORDS_PER_MINUTE,
+): number => {
+  if (!content || wordsPerMinute <= 0) {
+    return 0
+  }
+
+  const wordCount = getWordCount(extractReadingTimeText(content))
+
+  if (wordCount === 0) {
+    return 0
+  }
+
+  return Math.max(1, Math.ceil(wordCount / wordsPerMinute))
+}
+
+export const formatReadingTime = (minutes?: number | null): string | null => {
+  if (!minutes || minutes < 1) {
+    return null
+  }
+
+  return `${minutes} min read`
+}


### PR DESCRIPTION
# Describe your Changes:

## Reading time is now shown:

- on individual article pages in the article hero
- on article cards alongside author and publish date
- in archive, section, related-article, and search result cards

## What Changed:

- Added a reusable utility in readingTime.ts
- Add a server-side adapter for card payloads to show RTE
- Updated the article hero to display X min read in index.ts
- Updated **article components** to list views include the data needed to derive for RTE.
- Extended search so search-result cards can show 

## Notes:
- Reading Time Estimate is based on 200 WPM baseline.
- Reading time is from server-side article content

# Database changes:
This change adds new fields to the search collection/index:
- publishedAt
- populatedAuthors
- readingTimeMinutes

## Fixes: #34 